### PR TITLE
Examples update

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+node_modules/*
+.nyc_output/*
+examples/test.js
+examples/*.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bch-js-ext",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Extensions to @psf/bch-js library",
   "main": "src/bch-js-ext.js",
   "files": [


### PR DESCRIPTION
Fixed _simple_payment.js_ example to use the new TXBuilder format - inputs and outputs ass Arrays.